### PR TITLE
Fix drawing and obstacle logic

### DIFF
--- a/Classes/BasicEnemy.java
+++ b/Classes/BasicEnemy.java
@@ -145,10 +145,16 @@ public class BasicEnemy extends Enemy {
 				break;
 		}
 
-		if (!moving) {
-			g.drawImage(idleSpriteSheet, this.x + xOffset, this.y + yOffset, this.x + xOffset + spriteW, this.y + yOffset + spriteH, frame * spriteW, spriteRowNum * spriteH, (frame + 1)*spriteW, (spriteRowNum + 1)*spriteW, null);
-		} else {
-			g.drawImage(spriteSheet, this.x + xOffset, this.y + yOffset, this.x + xOffset + spriteW, this.y + yOffset + spriteH, frame * spriteW, spriteRowNum * spriteH, (frame + 1)*spriteW, (spriteRowNum + 1)*spriteW, null);
-		}
+                if (!moving) {
+                        g.drawImage(idleSpriteSheet, this.x + xOffset, this.y + yOffset,
+                                this.x + xOffset + spriteW, this.y + yOffset + spriteH,
+                                frame * spriteW, spriteRowNum * spriteH,
+                                (frame + 1) * spriteW, (spriteRowNum + 1) * spriteH, null);
+                } else {
+                        g.drawImage(spriteSheet, this.x + xOffset, this.y + yOffset,
+                                this.x + xOffset + spriteW, this.y + yOffset + spriteH,
+                                frame * spriteW, spriteRowNum * spriteH,
+                                (frame + 1) * spriteW, (spriteRowNum + 1) * spriteH, null);
+                }
 	}
 }

--- a/Classes/MapGenerator.java
+++ b/Classes/MapGenerator.java
@@ -86,12 +86,13 @@ public class MapGenerator {
             // Skip if this tile would overlap the player spawn
             if (rect.intersects(playerSpawn)) continue;
 
-            // Skip if this tile would overlap any entrances
+            // Skip if this tile would overlap or block an entrance
             boolean isEntranceOverlap = entrances.stream().anyMatch(e -> e.intersects(rect));
-            if (isNearEntrance(rect)) continue;
+            if (isEntranceOverlap || isNearEntrance(rect)) continue;
 
             // Skip if this tile would overlap any existing obstacle
-            if (isNearEntrance(rect)) continue;
+            boolean isObstacleOverlap = obstacles.stream().anyMatch(o -> o.intersects(rect));
+            if (isObstacleOverlap) continue;
 
             // Safe to place obstacle
             obstacles.add(new Rectangle(rect.x, rect.y, tileSize, tileSize));

--- a/Classes/Player.java
+++ b/Classes/Player.java
@@ -76,9 +76,15 @@ public class Player extends Character {
         }
 
         if (!moving) {
-            g2.drawImage(idleSpriteSheet, this.x + xOffset, this.y + yOffset, this.x + xOffset + spriteW, this.y + yOffset + spriteH, frame * spriteW, spriteRowNum * spriteH, (frame + 1)*spriteW, (spriteRowNum + 1)*spriteW, null);
+            g2.drawImage(idleSpriteSheet, this.x + xOffset, this.y + yOffset,
+                    this.x + xOffset + spriteW, this.y + yOffset + spriteH,
+                    frame * spriteW, spriteRowNum * spriteH,
+                    (frame + 1) * spriteW, (spriteRowNum + 1) * spriteH, null);
         } else {
-            g2.drawImage(spriteSheet, this.x + xOffset, this.y + yOffset, this.x + xOffset + spriteW, this.y + yOffset + spriteH, frame * spriteW, spriteRowNum * spriteH, (frame + 1)*spriteW, (spriteRowNum + 1)*spriteW, null);
+            g2.drawImage(spriteSheet, this.x + xOffset, this.y + yOffset,
+                    this.x + xOffset + spriteW, this.y + yOffset + spriteH,
+                    frame * spriteW, spriteRowNum * spriteH,
+                    (frame + 1) * spriteW, (spriteRowNum + 1) * spriteH, null);
         }
 
     }

--- a/Classes/ResourceLoader.java
+++ b/Classes/ResourceLoader.java
@@ -11,7 +11,7 @@ public class ResourceLoader {
      * @return The loaded BufferedImage, or null if not found
      */
     public static BufferedImage loadImage(String filename) {
-        try (InputStream is = ResourceLoader.class.getResourceAsStream("images\\" + filename)) {
+        try (InputStream is = ResourceLoader.class.getResourceAsStream("/images/" + filename)) {
             if (is == null) {
                 throw new IOException("Image not found: /images/" + filename);
             }


### PR DESCRIPTION
## Summary
- update obstacle generation to avoid entrance and obstacle overlap
- fix sprite rendering calculations in Player and BasicEnemy
- use portable path for ResourceLoader

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_683f05518570832bb4b33a069f2d7bbd