### PR TITLE
Implement power‑up system

### DIFF
--- a/Classes/MapGenerator.java
+++ b/Classes/MapGenerator.java
@@ -215,4 +215,56 @@ public class MapGenerator {
     public void updateLevel(int lvl) {
         this.level = lvl;
     }
+
+    /** Returns the tile size in pixels */
+    public int getTileSize() {
+        return tileSize;
+    }
+
+    /**
+     * Returns a list of rectangles representing walkable tiles (no obstacles,
+     * walls, or entrances).
+     */
+    public ArrayList<Rectangle> getWalkableTiles() {
+        ArrayList<Rectangle> tiles = new ArrayList<>();
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                Rectangle tile = new Rectangle(c * tileSize, r * tileSize, tileSize, tileSize);
+
+                boolean blocked = false;
+
+                if (tile.intersects(playerSpawn)) blocked = true;
+
+                if (!blocked) {
+                    for (Rectangle o : obstacles) {
+                        if (o.intersects(tile)) {
+                            blocked = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!blocked) {
+                    for (Rectangle e : entrances) {
+                        if (e.intersects(tile)) {
+                            blocked = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!blocked) {
+                    for (Rectangle w : walls) {
+                        if (w.intersects(tile)) {
+                            blocked = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (!blocked) tiles.add(tile);
+            }
+        }
+        return tiles;
+    }
 }

--- a/Classes/PowerUpItem.java
+++ b/Classes/PowerUpItem.java
@@ -1,0 +1,26 @@
+public class PowerUpItem extends java.awt.Rectangle {
+    private PowerUp powerUp;
+    private java.awt.image.BufferedImage image;
+    private java.awt.Color color;
+
+    public PowerUpItem(int x, int y, int size, PowerUp powerUp,
+                       java.awt.image.BufferedImage image, java.awt.Color color) {
+        super(x, y, size, size);
+        this.powerUp = powerUp;
+        this.image = image;
+        this.color = color;
+    }
+
+    public PowerUp getPowerUp() {
+        return powerUp;
+    }
+
+    public void draw(java.awt.Graphics2D g2, int xOffset, int yOffset) {
+        if (image != null) {
+            g2.drawImage(image, this.x + xOffset, this.y + yOffset, this.width, this.height, null);
+        } else {
+            g2.setColor(color);
+            g2.fillRect(this.x + xOffset, this.y + yOffset, this.width, this.height);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create `PowerUpItem` to represent collectible power-ups
- add methods in `MapGenerator` to expose tile size and walkable tiles
- spawn power-ups at the start of wave 6 and draw them on the map
- enable player pickup and activation of power-ups

## Testing
- `javac Classes/*.java`

------
https://chatgpt.com/codex/tasks/task_b_683f27f47568832b8325a6bb1248caa5