### PR TITLE
Fix music overlap and pause handling

### DIFF
--- a/Classes/Homepage.java
+++ b/Classes/Homepage.java
@@ -53,13 +53,13 @@ public class Homepage extends JFrame implements KeyListener {
 			repaint();
 		}
 
-		if (e.getKeyCode() == KeyEvent.VK_U) {
-			switch (button) {
-				case 1:
-					SoundPlayer.playSound("BackgroundMusic.wav");
-					this.dispose();
-					new Main();
-					break;
+                if (e.getKeyCode() == KeyEvent.VK_U) {
+                        switch (button) {
+                                case 1:
+                                        SoundPlayer.stopBackground();
+                                        this.dispose();
+                                        new Main();
+                                        break;
 				case 2:
 					if (instructions) instructions = false;
 					else instructions = true;

--- a/Classes/Main.java
+++ b/Classes/Main.java
@@ -109,9 +109,11 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 		this.setSize(screenSize.width, screenSize.height);
 		this.setExtendedState(JFrame.MAXIMIZED_BOTH);
 		this.setDefaultCloseOperation(EXIT_ON_CLOSE);
-		this.setLocationRelativeTo(null);
-		this.add(draw);
-		this.setVisible(true);
+                this.setLocationRelativeTo(null);
+                this.add(draw);
+                this.setVisible(true);
+
+                SoundPlayer.playBackground("BackgroundMusic.wav");
 
 		// Input and timer
 		this.addKeyListener(this);
@@ -337,20 +339,23 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 			return;
 		}
 
-		if (e.getKeyCode() == KeyEvent.VK_I && !paused) {
-			timer.stop();
-			paused = true;
-			repaint();
-			return;
-		} else if (e.getKeyCode() == KeyEvent.VK_U && paused && resume) {
-			paused = false;
-			timer.start();
-			return;
-		} else if (e.getKeyCode() == KeyEvent.VK_U && paused) {
-			this.dispose();
-			new Homepage();
-			return;
-		}
+                if (e.getKeyCode() == KeyEvent.VK_I && !paused) {
+                        timer.stop();
+                        SoundPlayer.pauseBackground();
+                        paused = true;
+                        repaint();
+                        return;
+                } else if (e.getKeyCode() == KeyEvent.VK_U && paused && resume) {
+                        paused = false;
+                        timer.start();
+                        SoundPlayer.resumeBackground();
+                        return;
+                } else if (e.getKeyCode() == KeyEvent.VK_U && paused) {
+                        SoundPlayer.stopBackground();
+                        this.dispose();
+                        new Homepage();
+                        return;
+                }
 
 		if (paused) {
 			if (e.getKeyCode() == KeyEvent.VK_W && !resume) {
@@ -401,13 +406,14 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 	@Override
 	public void actionPerformed(ActionEvent e) {
 
-		if (!player.isAlive()) {
-			timer.stop();
-			DeathScreen deathScreen = new DeathScreen();
-			deathScreen.updateScore(score.score);
-			this.dispose();
-			return;
-		}
+                if (!player.isAlive()) {
+                        timer.stop();
+                        SoundPlayer.stopBackground();
+                        DeathScreen deathScreen = new DeathScreen();
+                        deathScreen.updateScore(score.score);
+                        this.dispose();
+                        return;
+                }
 
 		//Set moving for animation
 		if (keysPressed.isEmpty()) {

--- a/Classes/SoundPlayer.java
+++ b/Classes/SoundPlayer.java
@@ -34,6 +34,20 @@ public class SoundPlayer {
         }
     }
 
+    /** Pauses the background audio without closing the clip. */
+    public static void pauseBackground() {
+        if (backgroundClip != null && backgroundClip.isRunning()) {
+            backgroundClip.stop();
+        }
+    }
+
+    /** Resumes a previously paused background audio clip. */
+    public static void resumeBackground() {
+        if (backgroundClip != null && !backgroundClip.isRunning()) {
+            backgroundClip.start();
+        }
+    }
+
     /**
      * Plays the specified audio file once from the /res/Audio directory.
      * @param filename The audio file name


### PR DESCRIPTION
## Summary
- stop background music when launching gameplay and play in-game loop
- add pause/resume support for background music
- pause and resume music with game pause state
- stop in-game music on exit or player death

## Testing
- `javac Classes/*.java`

------
https://chatgpt.com/codex/tasks/task_b_6841b94770ec832bab2db4036fce4573