### PR TITLE
Fix power-up stacking and UI clutter

### DIFF
--- a/Classes/Player.java
+++ b/Classes/Player.java
@@ -134,8 +134,19 @@ public class Player extends Character {
         powerUps.add(new InventoryPowerUp(p, icon));
     }
 
-    /** Activates the next unactivated power-up in FIFO order */
+    /**
+     * Activates the next stored power-up only if none are currently active.
+     * This prevents stacking multiple power-ups at the same time.
+     */
     public void usePowerUp() {
+        // Don't allow activation if one is already running
+        for (InventoryPowerUp ip : powerUps) {
+            if (ip.active) {
+                return;
+            }
+        }
+
+        // Activate the first inactive power-up in the queue
         for (InventoryPowerUp ip : powerUps) {
             if (!ip.active) {
                 ip.active = true;


### PR DESCRIPTION
## Summary
- prevent activating a new power-up while any is active
- group power-up icons on the HUD and show a count for duplicates

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_b_684324403fd0832bbdbe34b1e6e7395b