### PR TITLE
Fix wave start when paused

### DIFF
--- a/Classes/Main.java
+++ b/Classes/Main.java
@@ -322,12 +322,12 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 	 */
 	@Override
 	public void keyPressed(KeyEvent e) {
-		if (e.getKeyCode() == KeyEvent.VK_J && !waveInProgress) {
-			waveInProgress = true;
-			// Ensure no stray bullets from the previous wave carry
-			// over when the new wave begins
-			bullets.clear();
-			timer.start();
+                if (e.getKeyCode() == KeyEvent.VK_J && !waveInProgress && !paused) {
+                        waveInProgress = true;
+                        // Ensure no stray bullets from the previous wave carry
+                        // over when the new wave begins
+                        bullets.clear();
+                        timer.start();
 			player.x = (GAME_WIDTH - 70) / 2;
 			player.y = (GAME_WIDTH - 70) / 2;
 			return;
@@ -339,11 +339,13 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 			paused = true;
 			repaint();
 			return;
-		} else if (e.getKeyCode() == KeyEvent.VK_U && paused && resume) {
-			paused = false;
-			timer.start();
-			SoundPlayer.resumeBackground();
-			return;
+                } else if (e.getKeyCode() == KeyEvent.VK_U && paused && resume) {
+                        paused = false;
+                        if (waveInProgress) {
+                                timer.start();
+                        }
+                        SoundPlayer.resumeBackground();
+                        return;
 		} else if (e.getKeyCode() == KeyEvent.VK_U && paused) {
 			SoundPlayer.stopBackground();
 			this.dispose();


### PR DESCRIPTION
## Summary
- prevent starting a wave while the pause menu is open
- only resume the timer if a wave is already running

## Testing
- `bash compile.sh`

------
https://chatgpt.com/codex/tasks/task_b_68445e8b9864832ba7deabfb36f428f3