### PR TITLE
Fix pause overlay when resuming before first wave

### DIFF
--- a/Classes/Main.java
+++ b/Classes/Main.java
@@ -339,13 +339,14 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 			paused = true;
 			repaint();
 			return;
-		} else if (e.getKeyCode() == KeyEvent.VK_U && paused && resume) {
-			paused = false;
-			if (waveInProgress) {
-					timer.start();
-			}
-			SoundPlayer.resumeBackground();
-			return;
+                } else if (e.getKeyCode() == KeyEvent.VK_U && paused && resume) {
+                        paused = false;
+                        if (waveInProgress) {
+                                        timer.start();
+                        }
+                        SoundPlayer.resumeBackground();
+                        repaint();
+                        return;
 		} else if (e.getKeyCode() == KeyEvent.VK_U && paused) {
 			SoundPlayer.stopBackground();
 			this.dispose();


### PR DESCRIPTION
## Summary
- update pause/resume logic to repaint after resuming

## Testing
- `bash compile.sh`

------
https://chatgpt.com/codex/tasks/task_b_68447e5dc550832b898553f4719b64fc