### PR TITLE
Add healing items and separate power up keys

### DIFF
--- a/Classes/Bandage.java
+++ b/Classes/Bandage.java
@@ -1,0 +1,6 @@
+public class Bandage extends Heal {
+    @Override
+    public void apply(Player player) {
+        player.addHealth(1);
+    }
+}

--- a/Classes/Character.java
+++ b/Classes/Character.java
@@ -146,4 +146,26 @@ public abstract class Character extends Rectangle {
     public void addSpeed(double delta) {
         this.speed += delta;
     }
+
+    /**
+     * Adds the specified amount to the character's health without
+     * exceeding the maximum of 5.
+     * @param amount amount of hearts to restore
+     */
+    public void addHealth(int amount) {
+        this.health += amount;
+        if (this.health > 5) this.health = 5;
+        if (this.health < 0) this.health = 0;
+    }
+
+    /**
+     * Adds the specified amount to the character's shield without
+     * exceeding the maximum of 5.
+     * @param amount amount of shields to restore
+     */
+    public void addShield(int amount) {
+        this.shield += amount;
+        if (this.shield > 5) this.shield = 5;
+        if (this.shield < 0) this.shield = 0;
+    }
 }

--- a/Classes/Heal.java
+++ b/Classes/Heal.java
@@ -1,0 +1,4 @@
+public abstract class Heal {
+    /** Apply this heal effect to the given player */
+    public abstract void apply(Player player);
+}

--- a/Classes/HealItem.java
+++ b/Classes/HealItem.java
@@ -1,0 +1,30 @@
+public class HealItem extends java.awt.Rectangle {
+    private Heal heal;
+    private java.awt.image.BufferedImage image;
+    private java.awt.Color color;
+
+    public HealItem(int x, int y, int size, Heal heal,
+                    java.awt.image.BufferedImage image, java.awt.Color color) {
+        super(x, y, size, size);
+        this.heal = heal;
+        this.image = image;
+        this.color = color;
+    }
+
+    public Heal getHeal() {
+        return heal;
+    }
+
+    public java.awt.image.BufferedImage getImage() {
+        return image;
+    }
+
+    public void draw(java.awt.Graphics2D g2, int xOffset, int yOffset) {
+        if (image != null) {
+            g2.drawImage(image, this.x + xOffset, this.y + yOffset, this.width, this.height, null);
+        } else {
+            g2.setColor(color);
+            g2.fillRect(this.x + xOffset, this.y + yOffset, this.width, this.height);
+        }
+    }
+}

--- a/Classes/Player.java
+++ b/Classes/Player.java
@@ -20,6 +20,7 @@ public class Player extends Character {
     private boolean moving;
     private boolean shotgun;
     private LinkedList<InventoryPowerUp> powerUps = new LinkedList<>();
+    private LinkedList<InventoryHeal> heals = new LinkedList<>();
     BufferedImage spriteSheet = ResourceLoader.loadImage("PlayerSprite.png");
     BufferedImage idleSpriteSheet = ResourceLoader.loadImage("IdleSprite.png");
 
@@ -135,20 +136,18 @@ public class Player extends Character {
     }
 
     /**
-     * Activates the next stored power-up only if none are currently active.
-     * This prevents stacking multiple power-ups at the same time.
+     * Activates a stored power-up of the given type if one is not already active.
+     * @param type the class of power-up to activate
      */
-    public void usePowerUp() {
-        // Don't allow activation if one is already running
+    public void usePowerUp(Class<? extends PowerUp> type) {
         for (InventoryPowerUp ip : powerUps) {
-            if (ip.active) {
-                return;
+            if (type.isInstance(ip.powerUp) && ip.active) {
+                return; // already active
             }
         }
 
-        // Activate the first inactive power-up in the queue
         for (InventoryPowerUp ip : powerUps) {
-            if (!ip.active) {
+            if (type.isInstance(ip.powerUp) && !ip.active) {
                 ip.active = true;
                 ip.remaining = ip.powerUp.getDuration();
                 ip.powerUp.activate(this);
@@ -183,6 +182,30 @@ public class Player extends Character {
         return powerUps;
     }
 
+    /** Adds a heal item with its icon to the player's inventory */
+    public void addHeal(Heal h, BufferedImage icon) {
+        heals.add(new InventoryHeal(h, icon));
+    }
+
+    /**
+     * Uses and removes the first heal item of the given type.
+     * @param type the class of heal to use
+     */
+    public void useHeal(Class<? extends Heal> type) {
+        for (int i = 0; i < heals.size(); i++) {
+            InventoryHeal ih = heals.get(i);
+            if (type.isInstance(ih.heal)) {
+                ih.heal.apply(this);
+                heals.remove(i);
+                break;
+            }
+        }
+    }
+
+    public LinkedList<InventoryHeal> getHeals() {
+        return heals;
+    }
+
     /**
      * Class representing a collected power-up, its icon, and state
      */
@@ -197,6 +220,17 @@ public class Player extends Character {
             this.icon = icon;
             this.remaining = p.getDuration();
             this.active = false;
+        }
+    }
+
+    /** Class representing a collected heal item */
+    public static class InventoryHeal {
+        Heal heal;
+        BufferedImage icon;
+
+        InventoryHeal(Heal h, BufferedImage icon) {
+            this.heal = h;
+            this.icon = icon;
         }
     }
 }

--- a/Classes/ShieldPotion.java
+++ b/Classes/ShieldPotion.java
@@ -1,0 +1,6 @@
+public class ShieldPotion extends Heal {
+    @Override
+    public void apply(Player player) {
+        player.addShield(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add `Heal` classes for `Bandage` and `ShieldPotion`
- implement heal inventory in `Player`
- adjust `Character` for healing helpers
- spawn and draw heal items and split power-ups per key
- update key bindings and HUD display

## Testing
- `bash compile.sh`

------
https://chatgpt.com/codex/tasks/task_b_68470b8161d4832b8d9eb520f2473539