### PR TITLE
Add sound effects for power-ups and shotgun firing

### DIFF
--- a/Classes/Main.java
+++ b/Classes/Main.java
@@ -455,14 +455,15 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 	@Override
 	public void actionPerformed(ActionEvent e) {
 
-		if (!player.isAlive()) {
-			timer.stop();
-			SoundPlayer.stopBackground();
-			DeathScreen deathScreen = new DeathScreen();
-			deathScreen.updateScore(score.score);
-			this.dispose();
-			return;
-		}
+                if (!player.isAlive()) {
+                        timer.stop();
+                        player.deactivateAllPowerUps();
+                        SoundPlayer.stopBackground();
+                        DeathScreen deathScreen = new DeathScreen();
+                        deathScreen.updateScore(score.score);
+                        this.dispose();
+                        return;
+                }
 
 		//Set moving for animation
 		if (keysPressed.isEmpty()) {

--- a/Classes/Player.java
+++ b/Classes/Player.java
@@ -104,6 +104,7 @@ public class Player extends Character {
         int bulletY = this.y + (this.height - bulletH) / 2;
 
         if (shotgun) {
+            SoundPlayer.playSound("Shotgun.wav");
             double baseAngle = 0;
             switch (this.directionFacing) {
                 case 1 -> baseAngle = Math.PI;
@@ -166,6 +167,16 @@ public class Player extends Character {
                     ip.powerUp.deactivate(this);
                     powerUps.remove(i);
                 }
+            }
+        }
+    }
+
+    /** Deactivates all currently active power-ups without removing them. */
+    public void deactivateAllPowerUps() {
+        for (InventoryPowerUp ip : powerUps) {
+            if (ip.active) {
+                ip.powerUp.deactivate(this);
+                ip.active = false;
             }
         }
     }

--- a/Classes/Shotgun.java
+++ b/Classes/Shotgun.java
@@ -6,6 +6,7 @@ public class Shotgun extends PowerUp {
     @Override
     public void activate(Player player) {
         player.setShotgun(true);
+        SoundPlayer.playSound("ShotgunCycle.wav");
     }
 
     @Override

--- a/Classes/SoundPlayer.java
+++ b/Classes/SoundPlayer.java
@@ -49,10 +49,13 @@ public class SoundPlayer {
     }
 
     /**
-     * Plays the specified audio file once from the /res/Audio directory.
+     * Plays the specified audio file once from the /res/Audio directory and
+     * returns the Clip so callers may stop it early if desired.
+     *
      * @param filename The audio file name
+     * @return the Clip that is playing, or null if an error occurred
      */
-    public static void playSound(String filename) {
+    public static Clip playSound(String filename) {
         try (InputStream is = SoundPlayer.class.getResourceAsStream("/Audio/" + filename)) {
             if (is == null) {
                 throw new IOException("Audio not found: /Audio/" + filename);
@@ -61,9 +64,19 @@ public class SoundPlayer {
             Clip clip = AudioSystem.getClip();
             clip.open(ais);
             clip.start();
+            return clip;
         } catch (Exception e) {
             System.err.println("Error playing audio: " + filename);
             e.printStackTrace();
+        }
+        return null;
+    }
+
+    /** Stops and closes the provided Clip if it is not null. */
+    public static void stopClip(Clip clip) {
+        if (clip != null) {
+            clip.stop();
+            clip.close();
         }
     }
 }

--- a/Classes/SpeedBoost.java
+++ b/Classes/SpeedBoost.java
@@ -1,5 +1,8 @@
+import javax.sound.sampled.Clip;
+
 public class SpeedBoost extends PowerUp {
     private double boostAmount;
+    private Clip soundClip;
 
     public SpeedBoost(int duration, double boostAmount) {
         super(duration);
@@ -9,10 +12,13 @@ public class SpeedBoost extends PowerUp {
     @Override
     public void activate(Player player) {
         player.addSpeed(boostAmount);
+        soundClip = SoundPlayer.playSound("SpeedBoostSound.wav");
     }
 
     @Override
     public void deactivate(Player player) {
         player.addSpeed(-boostAmount);
+        SoundPlayer.stopClip(soundClip);
+        soundClip = null;
     }
 }


### PR DESCRIPTION
## Summary
- add sound when shooting with the shotgun
- play audio cues when Shotgun or Speed Boost power-ups activate
- stop power-up sounds when the player dies

## Testing
- `bash compile.sh`

------
https://chatgpt.com/codex/tasks/task_b_684758296274832b9bb7e7718eeed916