### PR TITLE
Fix shotgun icon aspect ratio

### DIFF
--- a/Classes/Main.java
+++ b/Classes/Main.java
@@ -709,11 +709,13 @@ public class Main extends JFrame implements ActionListener, KeyListener {
       if (speedActive) g2.drawString(String.valueOf(speedRemain / 100), bar1X, drawY + iconSize + 15);
 
       drawY += iconSize + 30;
-      g2.drawImage(shotgunIcon, bar1X, drawY, iconSize, iconSize, null);
-      g2.drawString("x" + shotgunCount, bar1X + iconSize - 15, drawY + iconSize - 5);
-      if (shotgunActive) g2.drawString(String.valueOf(shotgunRemain / 100), bar1X, drawY + iconSize + 15);
+      int shotgunH = iconSize;
+      int shotgunW = (int) (shotgunIcon.getWidth() * (shotgunH / (double) shotgunIcon.getHeight()));
+      g2.drawImage(shotgunIcon, bar1X, drawY, shotgunW, shotgunH, null);
+      g2.drawString("x" + shotgunCount, bar1X + shotgunW - 15, drawY + shotgunH - 5);
+      if (shotgunActive) g2.drawString(String.valueOf(shotgunRemain / 100), bar1X, drawY + shotgunH + 15);
 
-      drawY += iconSize + 40;
+      drawY += shotgunH + 40;
       g2.drawString("Heals", bar1X, drawY - 10);
       g2.drawImage(bandageIcon, bar1X, drawY, iconSize, iconSize, null);
       g2.drawString("x" + bandageCount, bar1X + iconSize - 15, drawY + iconSize - 5);

--- a/Classes/PowerUpItem.java
+++ b/Classes/PowerUpItem.java
@@ -21,7 +21,15 @@ public class PowerUpItem extends java.awt.Rectangle {
 
     public void draw(java.awt.Graphics2D g2, int xOffset, int yOffset) {
         if (image != null) {
-            g2.drawImage(image, this.x + xOffset, this.y + yOffset, this.width, this.height, null);
+            int drawW = this.width;
+            int drawH = (int) (drawW * image.getHeight() / (double) image.getWidth());
+            if (drawH > this.height) {
+                drawH = this.height;
+                drawW = (int) (drawH * image.getWidth() / (double) image.getHeight());
+            }
+            int drawX = this.x + xOffset + (this.width - drawW) / 2;
+            int drawY = this.y + yOffset + (this.height - drawH) / 2;
+            g2.drawImage(image, drawX, drawY, drawW, drawH, null);
         } else {
             g2.setColor(color);
             g2.fillRect(this.x + xOffset, this.y + yOffset, this.width, this.height);


### PR DESCRIPTION
## Summary
- keep image aspect ratio when drawing inventory shotgun icon
- keep aspect ratio when drawing PowerUp items

## Testing
- `bash compile.sh`

------
https://chatgpt.com/codex/tasks/task_b_684871d34eb0832b8e5bb7a38b80620d