### PR TITLE
Switch bullet rendering to shared sprite sheet

### DIFF
--- a/Classes/BouncingBullet.java
+++ b/Classes/BouncingBullet.java
@@ -1,8 +1,25 @@
 import java.awt.Rectangle;
 
+import java.awt.image.BufferedImage;
+
 public class BouncingBullet extends Bullet {
+
+    // Legacy bullet images used for shotgun power-up
+    private static final BufferedImage bulletLeft  = ResourceLoader.loadImage("BulletLeft.png");
+    private static final BufferedImage bulletRight = ResourceLoader.loadImage("BulletRight.png");
+    private static final BufferedImage bulletUp    = ResourceLoader.loadImage("BulletUp.png");
+    private static final BufferedImage bulletDown  = ResourceLoader.loadImage("BulletDown.png");
+
     public BouncingBullet(int x, int y, int w, int h, int panW, int panH, int direction) {
         super(x, y, w, h, panW, panH, direction);
+
+        // Replace the sprite sheet frame with the original images for shotgun bullets
+        switch (direction) {
+            case 1 -> bulletImage = bulletLeft;
+            case 2 -> bulletImage = bulletRight;
+            case 3 -> bulletImage = bulletUp;
+            case 4 -> bulletImage = bulletDown;
+        }
     }
 
     public void bounceX() {

--- a/Classes/Bullet.java
+++ b/Classes/Bullet.java
@@ -9,13 +9,15 @@ public class Bullet extends Rectangle {
 
 	private int vx, vy;       // Velocity components (direction and speed)
 	private int panW, panH;   // Dimensions of the game panel (for bounds checking)
-	private BufferedImage bulletImage;  // Individual bullet image for direction
+        // Image used when rendering this bullet
+        // Protected so subclasses like BouncingBullet can swap graphics
+        protected BufferedImage bulletImage;
 
-	// Static resources to load only once
-	private static final BufferedImage bulletLeft = ResourceLoader.loadImage("BulletLeft.png");
-	private static final BufferedImage bulletRight = ResourceLoader.loadImage("BulletRight.png");
-	private static final BufferedImage bulletUp = ResourceLoader.loadImage("BulletUp.png");
-	private static final BufferedImage bulletDown = ResourceLoader.loadImage("BulletDown.png");
+        // Static resources - single sprite sheet containing all bullet directions
+        private static final BufferedImage bulletSheet = ResourceLoader.loadImage("bulletSprites.png");
+        private static final int sheetCols = 4;
+        private static final int frameW = bulletSheet.getWidth() / sheetCols;
+        private static final int frameH = bulletSheet.getHeight();
 
 
 
@@ -30,16 +32,20 @@ public class Bullet extends Rectangle {
 	 * @param panH      Height of the game panel
 	 * @param direction Integer direction: 1=left, 2=right, 3=up, 4=down
 	 */
-	public Bullet(int x, int y, int w, int h, int panW, int panH, int direction) {
-		super(x, y, w, h);  // Initialize position and size via Rectangle superclass
+        public Bullet(int x, int y, int w, int h, int panW, int panH, int direction) {
+                super(x, y, w, h);  // Initialize position and size via Rectangle superclass
 
-		// Set bullet speed based on direction
-		switch (direction) {
-			case 1 -> { vx = -8; vy = 0; bulletImage = bulletLeft; }
-			case 2 -> { vx = 8; vy = 0; bulletImage = bulletRight; }
-			case 3 -> { vx = 0; vy = -8; bulletImage = bulletUp; }
-			case 4 -> { vx = 0; vy = 8; bulletImage = bulletDown; }
-		}
+                // Determine column in sprite sheet based on direction
+                int col = 0;
+
+                switch (direction) {
+                        case 1 -> { vx = -8; vy = 0; col = 3; } // left
+                        case 2 -> { vx = 8; vy = 0; col = 2; }  // right
+                        case 3 -> { vx = 0; vy = -8; col = 1; } // up
+                        case 4 -> { vx = 0; vy = 8; col = 0; }  // down
+                }
+
+                bulletImage = bulletSheet.getSubimage(col * frameW, 0, frameW, frameH);
 
 		this.panW = panW;
 		this.panH = panH;


### PR DESCRIPTION
## Summary
- use `bulletSprites.png` sprite sheet for bullet graphics
- compute frame coordinates based on direction
- retain old separate images for shotgun's bouncing bullets

## Testing
- `./compile.sh`


------
https://chatgpt.com/codex/tasks/task_b_684a45e09b40832b8597cc98bf810c7f