### PR TITLE
Fix death screen assets not visible

### DIFF
--- a/Classes/DeathScreen.java
+++ b/Classes/DeathScreen.java
@@ -94,7 +94,8 @@ public class DeathScreen extends JFrame implements KeyListener{
             g2.setColor(Color.BLACK);
             g2.fillRect(0, 0, screenWidth, screenHeight);
 
-            g2.drawImage(youDied, 1920, 1080 + yOffset, null);
+            // Draw the death screen background centered in the window
+            g2.drawImage(youDied, xOffset, yOffset, null);
 
             g2.setColor(new Color(199, 193, 159));
             g2.setFont(customFont.deriveFont(Font.PLAIN, 80));


### PR DESCRIPTION
## Summary
- center death screen image instead of drawing it off-screen

## Testing
- `bash compile.sh`
- `java -cp out Main` *(fails: `java.awt.HeadlessException`)*

------
https://chatgpt.com/codex/tasks/task_b_684a6277861c832baa5f65daa30b916b