### PR TITLE
Add scores screen using leaderboard panel

### DIFF
--- a/Classes/HighscoreManager.java
+++ b/Classes/HighscoreManager.java
@@ -20,7 +20,8 @@ public class HighscoreManager {
     }
 
     /**
-     * Sorts the high score file from highest to lowest score.
+     * Sorts the high score file from highest to lowest score and trims
+     * the list to the top 20 entries.
      */
     public static void sortScores() {
         File file = new File(FILE_NAME);
@@ -39,9 +40,11 @@ public class HighscoreManager {
             int sb = parseScore(b);
             return Integer.compare(sb, sa); // descending
         });
+        // Keep only the top 20 scores after sorting
+        int limit = Math.min(20, lines.size());
         try (PrintWriter pw = new PrintWriter(file)) {
-            for (String l : lines) {
-                pw.println(l);
+            for (int i = 0; i < limit; i++) {
+                pw.println(lines.get(i));
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/Classes/Homepage.java
+++ b/Classes/Homepage.java
@@ -106,10 +106,11 @@ public class Homepage extends JFrame implements KeyListener {
 					repaint();
 					break;
 
-				case 4:
-					score = !score;
-					repaint();
-					break;
+                                case 4:
+                                        SoundPlayer.stopBackground();
+                                        Homepage.this.dispose();
+                                        new ScoresScreen();
+                                        break;
 				case 5:
 					System.exit(0);
 					break;

--- a/Classes/LeaderboardPanel.java
+++ b/Classes/LeaderboardPanel.java
@@ -1,0 +1,155 @@
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.io.*;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Panel that displays the high score leaderboard. Text is centred
+ * in a resizable rectangle outline and supports scrolling with W/S.
+ */
+public class LeaderboardPanel extends JPanel implements KeyListener {
+
+    /** Number of leaderboard entries visible at once. */
+    private static final int VISIBLE_LINES = 7;
+
+    /** Padding around text inside the outline rectangle. */
+    private static final int PADDING = 40;
+
+    /** Parsed list of username/score pairs. */
+    private final List<ScoreEntry> scores = new ArrayList<>();
+
+    /** Font loaded from /res/Fonts */
+    private final Font font = FontLoader.loadFont("Game-Font.ttf");
+
+    /** Current scroll offset. */
+    private int scrollOffset = 0;
+
+    /** Optional player name used to highlight the player's own score. */
+    private final String playerName;
+
+    public LeaderboardPanel(String playerName) {
+        this.playerName = playerName;
+        setFocusable(true);
+        addKeyListener(this);
+        loadScores();
+    }
+
+    /** Convenience constructor when no player name highlighting is needed. */
+    public LeaderboardPanel() {
+        this(null);
+    }
+
+    /**
+     * Loads scores from highscores.txt. Ensures the file is sorted and
+     * trimmed via {@link HighscoreManager#sortScores()} first.
+     */
+    public final void loadScores() {
+        HighscoreManager.sortScores();
+        scores.clear();
+        File file = new File("highscores.txt");
+        if (!file.exists()) {
+            return;
+        }
+        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (!line.isBlank()) {
+                    int idx = line.lastIndexOf('-');
+                    if (idx != -1) {
+                        String name = line.substring(0, idx).trim();
+                        try {
+                            int sc = Integer.parseInt(line.substring(idx + 1).trim());
+                            scores.add(new ScoreEntry(name, sc));
+                        } catch (NumberFormatException ignored) {
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        // Ensure we do not scroll past the end after reloading
+        scrollOffset = Math.min(scrollOffset, Math.max(0, scores.size() - VISIBLE_LINES));
+    }
+
+    @Override
+    protected void paintComponent(Graphics g) {
+        super.paintComponent(g);
+        Graphics2D g2 = (Graphics2D) g;
+        g2.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING,
+                RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
+        // Bold, large font for arcade readability
+        g2.setFont(font.deriveFont(Font.BOLD, 60f));
+        FontMetrics fm = g2.getFontMetrics();
+        int lineHeight = fm.getHeight() + 10; // extra spacing between entries
+
+        int visible = Math.min(VISIBLE_LINES, scores.size());
+
+        // Calculate the maximum string width of the visible entries to size the rectangle
+        int maxWidth = 0;
+        for (int i = 0; i < visible; i++) {
+            ScoreEntry e = scores.get(i + scrollOffset);
+            String text = e.username + " - " + e.score;
+            maxWidth = Math.max(maxWidth, fm.stringWidth(text));
+        }
+
+        // Rectangle dimensions with padding on all sides
+        int rectWidth = maxWidth + PADDING * 2;
+        int rectHeight = lineHeight * visible + PADDING * 2 - 10; // minus extra spacing
+
+        // Center the rectangle in the panel
+        int rectX = (getWidth() - rectWidth) / 2;
+        int rectY = (getHeight() - rectHeight) / 2;
+
+        // Draw hollow rectangle
+        g2.setColor(Color.WHITE);
+        g2.drawRect(rectX, rectY, rectWidth, rectHeight);
+
+        // Draw the visible leaderboard entries centred within the rectangle
+        int y = rectY + PADDING + fm.getAscent();
+        for (int i = 0; i < visible; i++) {
+            int index = scrollOffset + i;
+            ScoreEntry entry = scores.get(index);
+            String text = entry.username + " - " + entry.score;
+            int textW = fm.stringWidth(text);
+            int x = rectX + (rectWidth - textW) / 2;
+
+            // Highlight the top score in gold, player's own score in cyan
+            if (index == 0) {
+                g2.setColor(new Color(255, 215, 0));
+            } else if (playerName != null && playerName.equalsIgnoreCase(entry.username)) {
+                g2.setColor(Color.CYAN);
+            } else {
+                g2.setColor(Color.WHITE);
+            }
+            g2.drawString(text, x, y);
+            y += lineHeight;
+        }
+    }
+
+    @Override
+    public void keyPressed(KeyEvent e) {
+        int code = e.getKeyCode();
+        if (code == KeyEvent.VK_W && scrollOffset > 0) {
+            scrollOffset--; // scroll up
+            repaint();
+        } else if (code == KeyEvent.VK_S && scrollOffset < Math.max(0, scores.size() - VISIBLE_LINES)) {
+            scrollOffset++; // scroll down
+            repaint();
+        }
+    }
+
+    @Override public void keyReleased(KeyEvent e) {}
+    @Override public void keyTyped(KeyEvent e) {}
+
+    /** Simple struct-like holder for parsed score lines. */
+    private static class ScoreEntry {
+        final String username;
+        final int score;
+        ScoreEntry(String u, int s) { this.username = u; this.score = s; }
+    }
+}

--- a/Classes/ScoresScreen.java
+++ b/Classes/ScoresScreen.java
@@ -3,19 +3,17 @@ import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.image.BufferedImage;
-import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
 
+/**
+ * Full-screen frame that shows the leaderboard using {@link LeaderboardPanel}.
+ * Press 'L' to return to the {@link Homepage}.
+ */
 public class ScoresScreen extends JFrame implements KeyListener {
     public static final int GAME_WIDTH = 1920;
     public static final int GAME_HEIGHT = 1080;
 
-    private BufferedImage background = ResourceLoader.loadImage("scoresBackground.jpg");
-    private Font customFont = FontLoader.loadFont("Game-Font.ttf");
-    private List<String> scores;
-    private int scrollIndex = 0;
-    private static final int VISIBLE_LINES = 10;
+    private final BufferedImage background = ResourceLoader.loadImage("scoresBackground.jpg");
+    private final LeaderboardPanel leaderboard;
 
     public ScoresScreen() {
         Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
@@ -25,50 +23,36 @@ public class ScoresScreen extends JFrame implements KeyListener {
         this.setUndecorated(true);
         this.setLocationRelativeTo(null);
 
-        loadScores();
+        leaderboard = new LeaderboardPanel();
+        leaderboard.setOpaque(false); // allow background to be visible
 
         DrawingPanel panel = new DrawingPanel(screenSize.width, screenSize.height);
+        panel.setLayout(new BorderLayout());
         panel.setFocusable(true);
         panel.requestFocusInWindow();
         panel.addKeyListener(this);
+        panel.add(leaderboard, BorderLayout.CENTER);
+
         this.add(panel);
         this.setVisible(true);
     }
 
-    private void loadScores() {
-        scores = new ArrayList<>();
-        File file = new File("highscores.txt");
-        if (!file.exists()) return;
-        try (BufferedReader br = new BufferedReader(new FileReader(file))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                if (!line.isBlank()) scores.add(line);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
     @Override
     public void keyPressed(KeyEvent e) {
-        int code = e.getKeyCode();
-        if (code == KeyEvent.VK_W && scrollIndex > 0) {
-            scrollIndex--;
-            repaint();
-        } else if (code == KeyEvent.VK_S && scrollIndex < Math.max(0, scores.size() - VISIBLE_LINES)) {
-            scrollIndex++;
-            repaint();
-        } else if (code == KeyEvent.VK_L) {
+        if (e.getKeyCode() == KeyEvent.VK_L) {
             this.dispose();
             new Homepage();
+        } else {
+            // Delegate scrolling keys to the leaderboard panel
+            leaderboard.keyPressed(e);
         }
     }
 
-    @Override public void keyTyped(KeyEvent e) {}
     @Override public void keyReleased(KeyEvent e) {}
+    @Override public void keyTyped(KeyEvent e) {}
 
     private class DrawingPanel extends JPanel {
-        private int screenWidth, screenHeight;
+        private final int screenWidth, screenHeight;
         public DrawingPanel(int w, int h) {
             this.screenWidth = w;
             this.screenHeight = h;
@@ -80,28 +64,10 @@ public class ScoresScreen extends JFrame implements KeyListener {
             Graphics2D g2 = (Graphics2D) g;
             g2.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 
-            int xOffset = (getWidth() - GAME_WIDTH) / 2;
-            int yOffset = (getHeight() - GAME_HEIGHT) / 2;
-
+            // Fill background and draw the image centered
             g2.setColor(Color.BLACK);
             g2.fillRect(0, 0, screenWidth, screenHeight);
             g2.drawImage(background, 0, 0, screenWidth, screenHeight, null);
-
-            int rectW = 800;
-            int rectH = 600;
-            int rectX = (getWidth() - rectW) / 2;
-            int rectY = (getHeight() - rectH) / 2;
-            g2.setColor(new Color(0, 0, 0, 180));
-            g2.fillRect(rectX, rectY, rectW, rectH);
-            g2.setColor(Color.WHITE);
-            g2.setFont(customFont.deriveFont(Font.PLAIN, 50));
-            int lineHeight = g2.getFontMetrics().getHeight();
-            for (int i = 0; i < VISIBLE_LINES; i++) {
-                int idx = scrollIndex + i;
-                if (idx >= scores.size()) break;
-                String line = scores.get(idx);
-                g2.drawString(line, rectX + 40, rectY + 80 + i * lineHeight);
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- integrate `LeaderboardPanel` via `ScoresScreen`
- open scores screen when selecting scores option in homepage

## Testing
- `bash compile.sh`


------
https://chatgpt.com/codex/tasks/task_b_684b06533de0832b8031736232cfa47b