### PR TITLE
Add damage feedback sound and overlay

### DIFF
--- a/Classes/Main.java
+++ b/Classes/Main.java
@@ -528,9 +528,11 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 
 		dealDamage();
 		aliveDead();
-		checkPowerUpPickup();
-		checkHealPickup();
-		player.updatePowerUps();
+                checkPowerUpPickup();
+                checkHealPickup();
+                player.updatePowerUps();
+                // Fade out damage visual effect
+                player.tickDamageEffect(TIMESPEED);
 
 
 		// Spawn enemies for current wave
@@ -773,25 +775,39 @@ public class Main extends JFrame implements ActionListener, KeyListener {
 				else g2.drawString("Wave " + (wave-1) + " Completed, Move Joystick to Continue", transX + (int)(50 * scale), transY + (int)(450 * scale));
 			}
 
-			if (paused) {
-				g2.drawImage(pauseBackground, transX, transY, worldW, worldH, null);
-				g2.setColor(Color.WHITE);
-				g2.drawString("Paused", transX + (int)(380 * scale), transY + (int)(400 * scale));
+                        if (paused) {
+                                g2.drawImage(pauseBackground, transX, transY, worldW, worldH, null);
+                                g2.setColor(Color.WHITE);
+                                g2.drawString("Paused", transX + (int)(380 * scale), transY + (int)(400 * scale));
 
-				if (resume) {
-					g2.setColor(Color.WHITE);
-					g2.drawString("Resume", transX + (int)(380 * scale), transY + (int)(500 * scale));
-					g2.setColor(Color.GRAY);
-					g2.drawString("Exit", transX + (int)(380 * scale), transY + (int)(550 * scale));
-				} else {
-					g2.setColor(Color.GRAY);
-					g2.drawString("Resume", transX + (int)(380 * scale), transY + (int)(500 * scale));
-					g2.setColor(Color.WHITE);
-					g2.drawString("Exit", transX + (int)(380 * scale), transY + (int)(550 * scale));
-				}
-			}
-		}
-	}
+                                if (resume) {
+                                        g2.setColor(Color.WHITE);
+                                        g2.drawString("Resume", transX + (int)(380 * scale), transY + (int)(500 * scale));
+                                        g2.setColor(Color.GRAY);
+                                        g2.drawString("Exit", transX + (int)(380 * scale), transY + (int)(550 * scale));
+                                } else {
+                                        g2.setColor(Color.GRAY);
+                                        g2.drawString("Resume", transX + (int)(380 * scale), transY + (int)(500 * scale));
+                                        g2.setColor(Color.WHITE);
+                                        g2.drawString("Exit", transX + (int)(380 * scale), transY + (int)(550 * scale));
+                                }
+                        }
+
+                        // Semi-transparent red border when taking damage
+                        int alpha = player.getDamageEffectAlpha();
+                        if (alpha > 0) {
+                                Composite oldC = g2.getComposite();
+                                g2.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, alpha / 255f));
+                                g2.setColor(Color.RED);
+                                int b = 50; // thickness of border
+                                g2.fillRect(0, 0, getWidth(), b); // top
+                                g2.fillRect(0, getHeight() - b, getWidth(), b); // bottom
+                                g2.fillRect(0, b, b, getHeight() - 2 * b); // left
+                                g2.fillRect(getWidth() - b, b, b, getHeight() - 2 * b); // right
+                                g2.setComposite(oldC);
+                        }
+                }
+        }
 
 	/** Helper class for displaying power-up icons with counts and timers */
 	private static class DisplayEntry {

--- a/Classes/Player.java
+++ b/Classes/Player.java
@@ -24,6 +24,14 @@ public class Player extends Character {
     BufferedImage walkingSpriteSheet = ResourceLoader.loadImage("playerWalk.png");
     BufferedImage idleSpriteSheet = ResourceLoader.loadImage("playerIdle.png");
 
+    // --- Damage feedback fields ---
+    /** Current alpha value for the damage screen effect */
+    private float damageEffectAlpha;
+    /** Timestamp of the last time damage feedback was triggered */
+    private long lastDamageTime;
+    /** Cooldown to avoid repeated triggering of feedback (ms) */
+    private static final int DAMAGE_COOLDOWN = 300;
+
     /**
      * Constructs a Player object with defined attributes and starting position.
      *
@@ -48,6 +56,39 @@ public class Player extends Character {
 
     public void setMoving(boolean moving) {
         this.moving = moving;
+    }
+
+    /**
+     * Overrides Character.updateHealth to add player specific feedback when
+     * damage is taken. A damage sound plays and the screen overlay is triggered
+     * with a short cooldown to prevent duplicate effects.
+     */
+    @Override
+    public void updateHealth(int damage) {
+        super.updateHealth(damage);
+
+        long now = System.currentTimeMillis();
+        if (now - lastDamageTime > DAMAGE_COOLDOWN) {
+            SoundPlayer.playSound("DamageNoise.wav");
+            damageEffectAlpha = 150f;
+            lastDamageTime = now;
+        }
+    }
+
+    /**
+     * Fades the damage overlay effect each game tick.
+     * @param deltaMs milliseconds since last tick
+     */
+    public void tickDamageEffect(int deltaMs) {
+        if (damageEffectAlpha > 0) {
+            float step = 150f * deltaMs / 1000f;
+            damageEffectAlpha = Math.max(0f, damageEffectAlpha - step);
+        }
+    }
+
+    /** Returns current alpha value for damage overlay. */
+    public int getDamageEffectAlpha() {
+        return (int) damageEffectAlpha;
     }
 
     /**


### PR DESCRIPTION
## Summary
- add damage effect tracking in Player
- play DamageNoise.wav and start fadeout overlay on damage
- tick damage fade each frame
- draw semi-transparent red border when player is hurt

## Testing
- `./compile.sh`

------
https://chatgpt.com/codex/tasks/task_b_684b7ebc6e54832ba886c4388ee093bf