### PR TITLE
Update project to target JDK 23

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21_PREVIEW" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_23" project-jdk-name="openjdk-23" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This project contains the source code for the game. No compiled class files are 
 
 ## Building
 
-The project expects Java 21. To compile all sources into the `out` directory run:
+The project expects Java 23. To compile all sources into the `out` directory run:
 
 ```bash
-javac --release 21 -d out Classes/*.java
+javac --release 23 -d out Classes/*.java
 ```
 
 If you previously built the game using a newer JDK, remove the `out` directory first to avoid "bad class file" version errors.

--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-# Compile all Java sources with Java 21
+# Compile all Java sources with Java 23
 mkdir -p out
-javac --release 21 -d out Classes/*.java
+javac --release 23 -d out Classes/*.java


### PR DESCRIPTION
## Summary
- upgrade compile script and README to JDK 23
- update IntelliJ config to use JDK 23

## Testing
- `sh compile.sh` *(fails: release version 23 not supported)*
- `javac --release 21 -d out Classes/*.java`
- `java -cp out Main` *(fails: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_b_684c6a20a95c832b95276bfd6ffc00f1