### PR TITLE
Fix heal usage at full health

### DIFF
--- a/Classes/Player.java
+++ b/Classes/Player.java
@@ -250,9 +250,20 @@ public class Player extends Character {
      * @param type the class of heal to use
      */
     public void useHeal(Class<? extends Heal> type) {
+        if (this.health >= 5 && this.shield >= 5) {
+            return; // already at full health and shield
+        }
+
         for (int i = 0; i < heals.size(); i++) {
             InventoryHeal ih = heals.get(i);
             if (type.isInstance(ih.heal)) {
+                if (ih.heal instanceof Bandage && this.health >= 5) {
+                    return; // can't heal health when already full
+                }
+                if (ih.heal instanceof ShieldPotion && this.shield >= 5) {
+                    return; // can't heal shield when already full
+                }
+
                 ih.heal.apply(this);
                 heals.remove(i);
                 break;


### PR DESCRIPTION
## Summary
- prevent using heal items when already at maximum health and shield
- skip consuming health-specific items if the respective stat is full

## Testing
- `./compile.sh` *(fails: release version 23 not supported)*

------
https://chatgpt.com/codex/tasks/task_b_68504996c1a8832b864cfdbc02a43442